### PR TITLE
Implement product_or_sector_specific_rules attribute for CarbonFootprint class

### DIFF
--- a/pathfinder_framework/carbon_footprint/carbon_footprint.py
+++ b/pathfinder_framework/carbon_footprint/carbon_footprint.py
@@ -14,6 +14,7 @@ from pathfinder_framework.data_quality_indicators.data_quality_indicators import
     DataQualityIndicators,
 )
 from pathfinder_framework.carbon_footprint.biogenic_accounting_methodology import BiogenicAccountingMethodology
+from pathfinder_framework.carbon_footprint.product_or_sector_specific_rule import ProductOrSectorSpecificRule
 
 
 class CarbonFootprint:
@@ -49,6 +50,7 @@ class CarbonFootprint:
         uncertainty_assessment_description (str | None): If present, the results, key drivers, and a short qualitative description of the uncertainty assessment.
         assurance (Assurance | None): If present, the Assurance information in accordance with the Pathfinder Framework.
         biogenic_accounting_methodology (BiogenicAccountingMethodology | None): The methodology used for biogenic carbon accounting.
+        product_or_sector_specific_rules (list[ProductOrSectorSpecificRule] | None): If present, refers to a set of product or sector specific rules published by a specific operator and applied during product carbon footprint calculation.
     """
 
     def __init__(
@@ -81,6 +83,7 @@ class CarbonFootprint:
         uncertainty_assessment_description=None,
         assurance=None,
         biogenic_accounting_methodology=None,
+        product_or_sector_specific_rules=None
     ):
         if not isinstance(declared_unit, DeclaredUnit):
             raise ValueError(
@@ -191,7 +194,13 @@ class CarbonFootprint:
             biogenic_accounting_methodology, BiogenicAccountingMethodology
         ):
             raise ValueError("biogenic_accounting_methodology must be an instance of BiogenicAccountingMethodology")
-
+        if product_or_sector_specific_rules is not None and not all(
+                isinstance(rule, ProductOrSectorSpecificRule)
+                for rule in product_or_sector_specific_rules
+        ):
+            raise ValueError(
+                "product_or_sector_specific_rules must be a list of ProductOrSectorSpecificRule"
+            )
         self.declared_unit = declared_unit
         self.unitary_product_amount = unitary_product_amount
         self.p_cf_excluding_biogenic = p_cf_excluding_biogenic
@@ -222,6 +231,7 @@ class CarbonFootprint:
         self.uncertainty_assessment_description = uncertainty_assessment_description
         self.assurance = assurance
         self.biogenic_accounting_methodology = biogenic_accounting_methodology
+        self.product_or_sector_specific_rules = product_or_sector_specific_rules
 
         required_attributes_before_2025 = ["primary_data_share", "dqi"]
         required_attributes_after_2025 = [

--- a/pathfinder_framework/carbon_footprint/product_or_sector_specific_rule.py
+++ b/pathfinder_framework/carbon_footprint/product_or_sector_specific_rule.py
@@ -1,0 +1,60 @@
+from pathfinder_framework.carbon_footprint.product_or_sector_specific_rule_operator import (
+    ProductOrSectorSpecificRuleOperator
+)
+
+
+class ProductOrSectorSpecificRule:
+    """
+    Represents a product or sector specific rule for calculating carbon footprints.
+
+    Attributes:
+        operator (ProductOrSectorSpecificRuleOperator): The operator that published the specific rule.
+        rule_names (list[str]): A list of names of the rules applied from the specified operator.
+        other_operator_name (str | None): The name of the operator if the operator is 'Other'.
+
+    Args:
+        operator (ProductOrSectorSpecificRuleOperator): The operator that published the specific rule.
+        rule_names (list[str]): A list of names of the rules applied from the specified operator.
+        other_operator_name (str | None): The name of the operator if the operator is 'Other'.
+
+    Raises:
+        ValueError: If the operator is 'Other' and other_operator_name is not provided, or if the operator is not
+                    'Other' and other_operator_name is provided.
+    """
+
+    def __init__(self,
+                 operator: ProductOrSectorSpecificRuleOperator,
+                 rule_names: list[str],
+                 other_operator_name: str | None = None):
+        if not isinstance(operator, ProductOrSectorSpecificRuleOperator):
+            raise ValueError("operator must be an instance of ProductOrSectorSpecificRuleOperator")
+
+        if not isinstance(rule_names, list) or not all(isinstance(rule, str) for rule in rule_names):
+            raise ValueError("rule_names must be a list of strings")
+
+        if operator == ProductOrSectorSpecificRuleOperator.OTHER and not other_operator_name:
+            raise ValueError("other_operator_name must be provided if operator is 'Other'")
+
+        if operator != ProductOrSectorSpecificRuleOperator.OTHER and other_operator_name:
+            raise ValueError("other_operator_name must not be provided if operator is not 'Other'")
+
+        self.operator = operator
+        self.rule_names = rule_names
+        self.other_operator_name = other_operator_name
+
+    def to_dict(self) -> dict:
+        """
+        Converts the ProductOrSectorSpecificRule instance to a dictionary representation.
+
+        Returns:
+            dict: A dictionary containing the operator, rule names, and other operator name if applicable.
+        """
+        rule_dict = {
+            "operator": self.operator.value,
+            "ruleNames": self.rule_names,
+        }
+
+        if self.operator == ProductOrSectorSpecificRuleOperator.OTHER:
+            rule_dict["otherOperatorName"] = self.other_operator_name
+
+        return rule_dict

--- a/pathfinder_framework/carbon_footprint/product_or_sector_specific_rule_operator.py
+++ b/pathfinder_framework/carbon_footprint/product_or_sector_specific_rule_operator.py
@@ -7,7 +7,7 @@ class ProductOrSectorSpecificRuleOperator(str, Enum):
 
     - PEF: for EU / PEF Methodology PCRs
     - EPD International: for PCRs authored or published by EPD International
-    - Other: for a PCR not published by the operators mentioned above
+    - OTHER: for a PCR not published by the operators mentioned above
 
     4.13.1. JSON Representation
     Each value is encoded as a JSON String.

--- a/tests/carbon_footprint/test_product_or_sector_specific_rule.py
+++ b/tests/carbon_footprint/test_product_or_sector_specific_rule.py
@@ -1,18 +1,20 @@
 import pytest
 
-from pathfinder_framework.carbon_footprint import ProductOrSectorSpecificRule
+from pathfinder_framework.carbon_footprint.product_or_sector_specific_rule import ProductOrSectorSpecificRule
 from pathfinder_framework.carbon_footprint.product_or_sector_specific_rule_operator import ProductOrSectorSpecificRuleOperator
 
 
 def test_product_or_sector_specific_rule_init():
-    with pytest.raises(NotImplementedError):
-        rule = ProductOrSectorSpecificRule(operator=ProductOrSectorSpecificRuleOperator.OTHER, rule_names=["Rule1"])
+    rule = ProductOrSectorSpecificRule(operator=ProductOrSectorSpecificRuleOperator.OTHER, rule_names=["Rule1"], other_operator_name="Custom Operator")
 
 
 def test_product_or_sector_specific_rule_to_dict():
-    with pytest.raises(NotImplementedError):
-        rule = ProductOrSectorSpecificRule(operator=ProductOrSectorSpecificRuleOperator.OTHER, rule_names=["Rule1"])
-        rule.to_dict()
+    rule = ProductOrSectorSpecificRule(operator=ProductOrSectorSpecificRuleOperator.OTHER, rule_names=["Rule1"], other_operator_name="Custom Operator")
+    assert rule.to_dict() == {
+        "operator": "Other",
+        "ruleNames": ["Rule1"],
+        "otherOperatorName": "Custom Operator",
+    }
 
 
 def test_init_with_invalid_operator():
@@ -25,18 +27,13 @@ def test_init_with_invalid_rule_names():
         ProductOrSectorSpecificRule(operator=ProductOrSectorSpecificRuleOperator.OTHER, rule_names="Invalid Rule Names")
 
 
-def test_init_with_valid_other_operator_name():
-    with pytest.raises(NotImplementedError):
-        ProductOrSectorSpecificRule(operator=ProductOrSectorSpecificRuleOperator.OTHER, rule_names=["Rule1"], other_operator_name="Other Operator")
-
-
 def test_init_without_mandatory_operator():
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         ProductOrSectorSpecificRule(rule_names=["Rule1"])
 
 
 def test_init_without_mandatory_rule_names():
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         ProductOrSectorSpecificRule(operator=ProductOrSectorSpecificRuleOperator.OTHER)
 
 
@@ -45,13 +42,11 @@ def test_other_operator_name_when_operator_not_other():
         ProductOrSectorSpecificRule(operator=ProductOrSectorSpecificRuleOperator.PEF, rule_names=["Rule1"], other_operator_name="Should not be set")
 
 
-@pytest.mark.parametrize("operator", [ProductOrSectorSpecificRuleOperator.OTHER, ProductOrSectorSpecificRuleOperator.EPD_INTERNATIONAL])
-def test_init_with_valid_operator(operator):
-    with pytest.raises(NotImplementedError):
-        ProductOrSectorSpecificRule(operator=operator, rule_names=["Rule1"])
+def test_init_with_valid_operator():
+    with pytest.raises(ValueError):
+        ProductOrSectorSpecificRule(operator=ProductOrSectorSpecificRuleOperator.OTHER, rule_names=["Rule1"])
 
 
-@pytest.mark.parametrize("rule_names", [["Rule1", "Rule2"], ["Rule1", "Rule2"]])
-def test_init_with_valid_rule_names(rule_names):
-    with pytest.raises(NotImplementedError):
-        ProductOrSectorSpecificRule(operator=ProductOrSectorSpecificRuleOperator.OTHER, rule_names=rule_names)
+def test_init_with_valid_rule_names():
+    with pytest.raises(ValueError):
+        ProductOrSectorSpecificRule(operator=ProductOrSectorSpecificRuleOperator.OTHER, rule_names=["Rule1", "Rule2"])

--- a/tests/carbon_footprint/test_product_or_sector_specific_rule.py
+++ b/tests/carbon_footprint/test_product_or_sector_specific_rule.py
@@ -1,0 +1,57 @@
+import pytest
+
+from pathfinder_framework.carbon_footprint import ProductOrSectorSpecificRule
+from pathfinder_framework.carbon_footprint.product_or_sector_specific_rule_operator import ProductOrSectorSpecificRuleOperator
+
+
+def test_product_or_sector_specific_rule_init():
+    with pytest.raises(NotImplementedError):
+        rule = ProductOrSectorSpecificRule(operator=ProductOrSectorSpecificRuleOperator.OTHER, rule_names=["Rule1"])
+
+
+def test_product_or_sector_specific_rule_to_dict():
+    with pytest.raises(NotImplementedError):
+        rule = ProductOrSectorSpecificRule(operator=ProductOrSectorSpecificRuleOperator.OTHER, rule_names=["Rule1"])
+        rule.to_dict()
+
+
+def test_init_with_invalid_operator():
+    with pytest.raises(ValueError):
+        ProductOrSectorSpecificRule(operator="Invalid Operator", rule_names=["Rule1"])
+
+
+def test_init_with_invalid_rule_names():
+    with pytest.raises(ValueError):
+        ProductOrSectorSpecificRule(operator=ProductOrSectorSpecificRuleOperator.OTHER, rule_names="Invalid Rule Names")
+
+
+def test_init_with_valid_other_operator_name():
+    with pytest.raises(NotImplementedError):
+        ProductOrSectorSpecificRule(operator=ProductOrSectorSpecificRuleOperator.OTHER, rule_names=["Rule1"], other_operator_name="Other Operator")
+
+
+def test_init_without_mandatory_operator():
+    with pytest.raises(ValueError):
+        ProductOrSectorSpecificRule(rule_names=["Rule1"])
+
+
+def test_init_without_mandatory_rule_names():
+    with pytest.raises(ValueError):
+        ProductOrSectorSpecificRule(operator=ProductOrSectorSpecificRuleOperator.OTHER)
+
+
+def test_other_operator_name_when_operator_not_other():
+    with pytest.raises(ValueError):
+        ProductOrSectorSpecificRule(operator=ProductOrSectorSpecificRuleOperator.PEF, rule_names=["Rule1"], other_operator_name="Should not be set")
+
+
+@pytest.mark.parametrize("operator", [ProductOrSectorSpecificRuleOperator.OTHER, ProductOrSectorSpecificRuleOperator.EPD_INTERNATIONAL])
+def test_init_with_valid_operator(operator):
+    with pytest.raises(NotImplementedError):
+        ProductOrSectorSpecificRule(operator=operator, rule_names=["Rule1"])
+
+
+@pytest.mark.parametrize("rule_names", [["Rule1", "Rule2"], ["Rule1", "Rule2"]])
+def test_init_with_valid_rule_names(rule_names):
+    with pytest.raises(NotImplementedError):
+        ProductOrSectorSpecificRule(operator=ProductOrSectorSpecificRuleOperator.OTHER, rule_names=rule_names)

--- a/tests/carbon_footprint/test_product_or_sector_specific_rule.py
+++ b/tests/carbon_footprint/test_product_or_sector_specific_rule.py
@@ -1,52 +1,82 @@
 import pytest
 
-from pathfinder_framework.carbon_footprint.product_or_sector_specific_rule import ProductOrSectorSpecificRule
-from pathfinder_framework.carbon_footprint.product_or_sector_specific_rule_operator import ProductOrSectorSpecificRuleOperator
+from pathfinder_framework.carbon_footprint.product_or_sector_specific_rule import (
+    ProductOrSectorSpecificRule,
+)
+from pathfinder_framework.carbon_footprint.product_or_sector_specific_rule_operator import (
+    ProductOrSectorSpecificRuleOperator,
+)
 
 
-def test_product_or_sector_specific_rule_init():
-    rule = ProductOrSectorSpecificRule(operator=ProductOrSectorSpecificRuleOperator.OTHER, rule_names=["Rule1"], other_operator_name="Custom Operator")
-
-
-def test_product_or_sector_specific_rule_to_dict():
-    rule = ProductOrSectorSpecificRule(operator=ProductOrSectorSpecificRuleOperator.OTHER, rule_names=["Rule1"], other_operator_name="Custom Operator")
-    assert rule.to_dict() == {
-        "operator": "Other",
-        "ruleNames": ["Rule1"],
-        "otherOperatorName": "Custom Operator",
+@pytest.fixture
+def valid_product_or_sector_specific_rule():
+    return {
+        "operator": ProductOrSectorSpecificRuleOperator.OTHER,
+        "rule_names": ["Rule1"],
+        "other_operator_name": "Custom Operator",
     }
 
 
-def test_init_with_invalid_operator():
-    with pytest.raises(ValueError):
-        ProductOrSectorSpecificRule(operator="Invalid Operator", rule_names=["Rule1"])
+def test_product_or_sector_specific_rule_init_valid(valid_product_or_sector_specific_rule):
+    rule = ProductOrSectorSpecificRule(**valid_product_or_sector_specific_rule)
+    assert rule.operator == ProductOrSectorSpecificRuleOperator.OTHER
+    assert rule.rule_names == ["Rule1"]
+    assert rule.other_operator_name == "Custom Operator"
 
 
-def test_init_with_invalid_rule_names():
-    with pytest.raises(ValueError):
-        ProductOrSectorSpecificRule(operator=ProductOrSectorSpecificRuleOperator.OTHER, rule_names="Invalid Rule Names")
+def test_product_or_sector_specific_rule_init_invalid_operator(valid_product_or_sector_specific_rule):
+    invalid_rule = {
+        **valid_product_or_sector_specific_rule,
+        "operator": "Invalid Operator",
+    }
+    with pytest.raises(ValueError, match="operator must be an instance of ProductOrSectorSpecificRuleOperator"):
+        ProductOrSectorSpecificRule(**invalid_rule)
 
 
-def test_init_without_mandatory_operator():
-    with pytest.raises(TypeError):
-        ProductOrSectorSpecificRule(rule_names=["Rule1"])
+def test_product_or_sector_specific_rule_init_invalid_rule_names(valid_product_or_sector_specific_rule):
+    invalid_rule = {
+        **valid_product_or_sector_specific_rule,
+        "rule_names": "Invalid Rule Names"
+    }
+    with pytest.raises(ValueError, match="rule_names must be a list of strings"):
+        ProductOrSectorSpecificRule(**invalid_rule)
 
 
-def test_init_without_mandatory_rule_names():
-    with pytest.raises(TypeError):
-        ProductOrSectorSpecificRule(operator=ProductOrSectorSpecificRuleOperator.OTHER)
+def test_product_or_sector_specific_rule_init_missing_operator():
+    invalid_rule = {"rule_names": ["Rule1"]}
+    with pytest.raises(TypeError, match="missing 1 required positional argument: 'operator'"):
+        ProductOrSectorSpecificRule(**invalid_rule)
 
 
-def test_other_operator_name_when_operator_not_other():
-    with pytest.raises(ValueError):
-        ProductOrSectorSpecificRule(operator=ProductOrSectorSpecificRuleOperator.PEF, rule_names=["Rule1"], other_operator_name="Should not be set")
+def test_product_or_sector_specific_rule_init_missing_rule_names():
+    invalid_rule = {"operator": ProductOrSectorSpecificRuleOperator.OTHER}
+    with pytest.raises(TypeError, match="missing 1 required positional argument: 'rule_names'"):
+        ProductOrSectorSpecificRule(**invalid_rule)
 
 
-def test_init_with_valid_operator():
-    with pytest.raises(ValueError):
-        ProductOrSectorSpecificRule(operator=ProductOrSectorSpecificRuleOperator.OTHER, rule_names=["Rule1"])
+def test_product_or_sector_specific_rule_init_other_operator_name_when_operator_not_other(valid_product_or_sector_specific_rule):
+    invalid_rule = {
+        **valid_product_or_sector_specific_rule,
+        "operator": ProductOrSectorSpecificRuleOperator.PEF,
+        "other_operator_name": "Should not be set"
+    }
+    with pytest.raises(ValueError, match="other_operator_name must not be provided if operator is not 'Other'"):
+        ProductOrSectorSpecificRule(**invalid_rule)
 
 
-def test_init_with_valid_rule_names():
-    with pytest.raises(ValueError):
-        ProductOrSectorSpecificRule(operator=ProductOrSectorSpecificRuleOperator.OTHER, rule_names=["Rule1", "Rule2"])
+def test_product_or_sector_specific_rule_init_valid_rule_names():
+    rule = {
+        "operator": ProductOrSectorSpecificRuleOperator.OTHER,
+        "rule_names": ["Rule1", "Rule2"],
+        "other_operator_name": "Custom Operator",
+    }
+    ProductOrSectorSpecificRule(**rule)
+
+
+def test_product_or_sector_specific_rule_to_dict(valid_product_or_sector_specific_rule):
+    rule = ProductOrSectorSpecificRule(**valid_product_or_sector_specific_rule)
+    assert rule.to_dict() == {
+        "operator": ProductOrSectorSpecificRuleOperator.OTHER,
+        "ruleNames": ["Rule1"],
+        "otherOperatorName": "Custom Operator",
+    }


### PR DESCRIPTION
Resolves #16 by adding a new module in `product_or_sector_specific_rule.py` with tests, and adds a new attribute onto the CarbonFootprint class to fix the issue.